### PR TITLE
Missing space in use_description_field

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -77,7 +77,7 @@ use_dependency <- function(package, type, min_version = NULL) {
     if (existing_type != "LinkingTo") {
       ui_done(
         "
-        Moving {ui_value(package)} from {ui_field(existing_type)} to {ui_field(type)}\\
+        Moving {ui_value(package)} from {ui_field(existing_type)} to {ui_field(type)} \\
         field in DESCRIPTION
         "
       )


### PR DESCRIPTION
There is a missing space in the UI warning when switching a package between fields.